### PR TITLE
Avoid runtime error when editor is null

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -73,8 +73,12 @@ const activate = ctx => {
 
   vscode.workspace.onDidSaveTextDocument(document => checkAutoItCode(document));
   vscode.workspace.onDidOpenTextDocument(document => checkAutoItCode(document));
-  vscode.window.onDidChangeActiveTextEditor(editor => checkAutoItCode(editor.document));
-
+  vscode.window.onDidChangeActiveTextEditor(editor => {
+    if (editor) {
+      checkAutoItCode(editor.document)
+    }
+  });
+  
   // eslint-disable-next-line no-console
   console.log('AutoIt is now active!');
 };


### PR DESCRIPTION
Active editor can be undefined, so test it before calling checkAutoItCode