### PR TITLE
Use AutoIt3Wrapper when performing code check

### DIFF
--- a/src/ai_commands.js
+++ b/src/ai_commands.js
@@ -216,7 +216,7 @@ const checkScript = () => {
   window.setStatusBarMessage(`Checking script...${thisFile}`, 1500);
 
   // Launch the AutoIt Wrapper executable with the script's path
-  procRunner(checkPath, [thisFile]);
+  procRunner(aiPath, [wrapperPath, '/AU3check', '/prod', '/in', thisFile]);
 };
 
 const buildScript = () => {


### PR DESCRIPTION
This matches Scite functionality so that AuttoIt3Wrapper directives added to your script are used when executing `extension.check` 