### PR TITLE
Make regex for #include non-greedy

### DIFF
--- a/syntaxes/autoit.YAML-tmLanguage
+++ b/syntaxes/autoit.YAML-tmLanguage
@@ -35,7 +35,7 @@ patterns:
                 name: punctuation.definition.string.begin.import.autoit
             '3':
                 name: punctuation.definition.string.end.import.autoit
-        match: '#(?i:include)\s+((["''<]).*(["''>]))'
+        match: '#(?i:include)\s+((["''<]).*?(["''>]))'
         name: keyword.control.import.autoit
     -
         captures:

--- a/syntaxes/autoit.tmLanguage
+++ b/syntaxes/autoit.tmLanguage
@@ -79,7 +79,7 @@
           </dict>
         </dict>
         <key>match</key>
-        <string>#(?i:include)\s+((["'&lt;]).*(["'&gt;]))</string>
+        <string>#(?i:include)\s+((["'&lt;]).*?(["'&gt;]))</string>
         <key>name</key>
         <string>keyword.control.import.autoit</string>
       </dict>


### PR DESCRIPTION
Current inplementation doesn't correctly handle ">" in comment portion of line. Ex: 
```autoit
#include <Misc.au3> ; Needed For _WD_UpdateDriver >> _VersionCompare
```