### PR TITLE
Fix Au3Stripper

### DIFF
--- a/syntaxes/autoit.tmLanguage
+++ b/syntaxes/autoit.tmLanguage
@@ -101,7 +101,7 @@
         <key>name</key>
         <string>keyword.control.directives.autoit</string>
         <key>match</key>
-        <string>^\s*(#)(AutoIt3Wrapper_\w+|Au3Stripper_parameters|Tidy_Parameters)\b</string>
+        <string>^\s*(#)(AutoIt3Wrapper_\w+|Au3Stripper_\w+|Tidy_Parameters)\b</string>
         <key>captures</key>
         <dict>
           <key>1</key>


### PR DESCRIPTION
Fixes #109

Adds:
- #Au3Stripper_Off
- #Au3Stripper_On
- #Au3Stripper_AlwaysStrip_Off
- #Au3Stripper_AlwaysStrip_On
- #Au3Stripper_Ignore_Funcs
- #Au3Stripper_Ignore_Errors_in_Funcs
- #Au3Stripper_Ignore_Variables

Fixes:
- Syntax highlighting failing if `P` in `Parameters` is upper case