### PR TITLE
Keybinding error message fix and more

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-prettier": "^3.3.1",
+        "json5": "^2.2.1",
         "prettier": "^1.19.1",
         "typescript": "^3.5.3",
         "webpack": "^5.12.2",
@@ -87,21 +88,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@babel/core/node_modules/json5": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@babel/core/node_modules/ms": {
@@ -3577,15 +3563,15 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
       "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
       "bin": {
         "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/kind-of": {
@@ -3646,6 +3632,18 @@
       },
       "engines": {
         "node": ">=4.0.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/locate-path": {
@@ -4765,21 +4763,6 @@
         "strip-bom": "^3.0.0"
       }
     },
-    "node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "dev": true,
-      "dependencies": {
-        "minimist": "^1.2.5"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -5198,15 +5181,6 @@
           "dev": true,
           "requires": {
             "ms": "2.1.2"
-          }
-        },
-        "json5": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-          "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -7969,13 +7943,10 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -8020,6 +7991,17 @@
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
         "json5": "^1.0.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        }
       }
     },
     "locate-path": {
@@ -8897,17 +8879,6 @@
         "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
-      },
-      "dependencies": {
-        "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
-          }
-        }
       }
     },
     "tslib": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-prettier": "^3.3.1",
-        "json5": "^2.2.1",
+        "jsonc-parser": "^3.2.0",
         "prettier": "^1.19.1",
         "typescript": "^3.5.3",
         "webpack": "^5.12.2",
@@ -3573,6 +3573,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
+      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -7946,6 +7952,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "dev": true
+    },
+    "jsonc-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
     "kind-of": {

--- a/package.json
+++ b/package.json
@@ -424,7 +424,30 @@
             "On each line"
           ],
           "description": "Show process ID in the Autoit (common) output"
+        },
+        "autoit.outputShowTime": {
+          "type": "string",
+          "default": "None",
+          "enum": [
+            "None",
+            "Global",
+            "Process",
+            "All"
+          ],
+          "enumDescriptions": [
+            "Don't time for each message",
+            "Show time in global output",
+            "Show time in process output",
+            "Show time in all outputs"
+          ],
+          "description": "Show time when each output line was received"
+        },
+        "autoit.outputMaxHistoryLines": {
+          "type": "number",
+          "default": 5000,
+          "description": "Number of output lines to keep"
         }
+
       }
     },
     "configurationDefaults": {
@@ -530,6 +553,12 @@
             "scope": "vscode-autoit-output-olive",
             "settings": {
               "foreground": "#808000"
+            }
+          },
+          {
+            "scope": "vscode-autoit-output-date",
+            "settings": {
+              "foreground": "#83817a"
             }
           }
         ]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
+    "json5": "^2.2.1",
     "prettier": "^1.19.1",
     "typescript": "^3.5.3",
     "webpack": "^5.12.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-prettier": "^3.3.1",
-    "json5": "^2.2.1",
+    "jsonc-parser": "^3.2.0",
     "prettier": "^1.19.1",
     "typescript": "^3.5.3",
     "webpack": "^5.12.2",
@@ -409,7 +409,6 @@
           "type": "boolean",
           "default": true,
           "description": "Terminate running script when script file is closed"
-      
         },
         "autoit.processIdInOutput": {
           "type": "string",
@@ -533,7 +532,6 @@
               "foreground": "#808000"
             }
           }
-
         ]
       }
     }

--- a/src/ai_commands.js
+++ b/src/ai_commands.js
@@ -220,8 +220,9 @@ const AiOut = ({ id, aiOutProcess }) => {
       prevLineTimer,
       isNewLineProcess = true;
 
-  const prefixId = "#" + id + ": ",
-    prefixEmpty = "".padStart(prefixId.length, " "), //using U+00A0 NO-BREAK SPACE character
+  const spacer = " ", //using U+00A0 NO-BREAK SPACE character to avoid white-space character highlight.
+    prefixId = "#" + id + ":" + spacer,
+    prefixEmpty = "".padStart(prefixId.length, spacer),
     hotkeyFailedMsg = /!!?>Failed Setting Hotkey\(s\)(?::|...)[\r\n]*|(?:false)?--> SetHotKey (?:\(\) )?Restart failed(?:,|. -->) SetHotKey (?:\(\) )?Stop failed\.[\r\n]*/gi,
     outputText = (aiOut, prop, lines) => { //using separate function, for performance, so it doesn't have to be created for each message
       const time = getTime();
@@ -243,7 +244,7 @@ const AiOut = ({ id, aiOutProcess }) => {
             break;
 
           if (isNewLineProcess)
-            linesProcess[i] = time + " " + linesProcess[i];
+            linesProcess[i] = time + spacer + linesProcess[i];
 
           isNewLineProcess = true;
         }
@@ -259,7 +260,7 @@ const AiOut = ({ id, aiOutProcess }) => {
         runners.isNewLine = true;
       }
 
-      const prefixTime = (config.outputShowTime == "Global" || config.outputShowTime == "All") ? time + " " : "";
+      const prefixTime = (config.outputShowTime == "Global" || config.outputShowTime == "All") ? time + spacer : "";
       for(let i = 0; i < lines.length; i++) {
         if (i == lines.length-1 && lines[i] === "")
           break;

--- a/src/commandsList.js
+++ b/src/commandsList.js
@@ -1,0 +1,20 @@
+export const commandsPrefix = "extension.";
+//key = command, value = function name
+export const commandsList = [
+  'runScript',
+  'launchHelp',
+  'launchInfo',
+  'debugMsgBox',
+  'debugConsole',
+  'compile',
+  'tidy',
+  'check',
+  'build',
+  'launchKoda',
+  'changeParams',
+  'killScript',
+  'killScriptOpened',
+  'openInclude',
+  'insertHeader',
+  'restartScript',
+];

--- a/src/registerCommands.js
+++ b/src/registerCommands.js
@@ -1,12 +1,12 @@
 import { commands } from 'vscode';
 import * as aiCommands from './ai_commands';
-import { commandsList, commandPrefix } from "./commandsList";
+import { commandsList, commandsPrefix } from "./commandsList";
 
 export const registerCommands = () => {
   for(let i = 0; i < commandsList.length; i++) {
     const command = commandsList[i];
     if (aiCommands[command])
-      commands.registerCommand(commandPrefix + command, aiCommands[command]);
+      commands.registerCommand(commandsPrefix + command, aiCommands[command]);
   }
 };
 

--- a/src/registerCommands.js
+++ b/src/registerCommands.js
@@ -1,46 +1,13 @@
 import { commands } from 'vscode';
-import {
-  buildScript,
-  changeConsoleParams,
-  checkScript,
-  compileScript,
-  debugConsole,
-  debugMsgBox,
-  killScript,
-  killScriptOpened,
-  launchHelp,
-  launchInfo,
-  launchKoda,
-  runScript,
-  tidyScript,
-  openInclude,
-  insertHeader,
-  restartScript,
-} from './ai_commands';
-
-const commandList = [
-  { id: 'extension.runScript', func: runScript },
-  { id: 'extension.launchHelp', func: launchHelp },
-  { id: 'extension.launchInfo', func: launchInfo },
-  { id: 'extension.debugMsgBox', func: debugMsgBox },
-  { id: 'extension.debugConsole', func: debugConsole },
-  { id: 'extension.compile', func: compileScript },
-  { id: 'extension.tidy', func: tidyScript },
-  { id: 'extension.check', func: checkScript },
-  { id: 'extension.build', func: buildScript },
-  { id: 'extension.launchKoda', func: launchKoda },
-  { id: 'extension.changeParams', func: changeConsoleParams },
-  { id: 'extension.killScript', func: killScript },
-  { id: 'extension.killScriptOpened', func: killScriptOpened },
-  { id: 'extension.openInclude', func: openInclude },
-  { id: 'extension.insertHeader', func: insertHeader },
-  { id: 'extension.restartScript', func: restartScript },
-];
+import * as aiCommands from './ai_commands';
+import { commandsList, commandPrefix } from "./commandsList";
 
 export const registerCommands = () => {
-  commandList.forEach(command => {
-    commands.registerCommand(command.id, command.func);
-  });
+  for(let i = 0; i < commandsList.length; i++) {
+    const command = commandsList[i];
+    if (aiCommands[command])
+      commands.registerCommand(commandPrefix + command, aiCommands[command]);
+  }
 };
 
 export default 'registerCommands';

--- a/syntaxes/vscode-autoit-output.tmLanguage.json
+++ b/syntaxes/vscode-autoit-output.tmLanguage.json
@@ -4,26 +4,37 @@
   "scopeName": "source.vscode_autoit_output",
   "patterns": [
     {
-      "match": "^(#[0-9]+: | {4,})?((?:---|\\+\\+\\+).*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?((?:---|\\+\\+\\+).*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-brown"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-date"},
+        "3": {"name": "vscode-autoit-output-brown"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?((?:Warning|Error).*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?((?:---|\\+\\+\\+).*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-chocolate"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-brown"}
       }
     },
     {
-      "begin": "^(#[0-9]+: | {4,})?(Starting process (#[0-9]+))",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?((?:Warning|Error).*)",
+      "captures":{
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-chocolate"}
+      }
+    },
+    {
+      "begin": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(Starting process (#\\d+))",
       "end": "((.+) \\[PID ([0-9]+|n\/a)\\])",
       "beginCaptures": {
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-process"},
-        "3": {"name": "vscode-autoit-output-process-id"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-process"},
+        "4": {"name": "vscode-autoit-output-process-id"}
       },
       "endCaptures": {
         "1": {"name": "vscode-autoit-output-process"},
@@ -32,86 +43,100 @@
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?([>].*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?([>].*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-blue"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-blue"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?([+].*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?([+].*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-green"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-green"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?([-<].*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?([-<].*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-orange"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-orange"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?([!].*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?([!].*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-bold-red"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-bold-red"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?(.*:([0-9]+):)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(.*:([0-9]+):)?",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-purple"},
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-purple"},
+        "4": {"name": "vscode-autoit-output-purple"}
+      }
+    },
+    {
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(.*\\son line\\s([0-9]*).*)",
+      "captures":{
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-red"}
+      }
+    },
+    {
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(@@ Debug\\(\\d+\\) :)",
+      "captures":{
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-debug"}
+      }
+    },
+    {
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(.*\\(\\d+\\).*)",
+      "captures":{
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-olive"}
+      }
+    },
+    {
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(In file included from\\s.*)",
+      "captures":{
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
         "3": {"name": "vscode-autoit-output-purple"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?(.*\\son line\\s([0-9]*).*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(line(?:\\s|.)*\\scolumn(?:\\s|.)*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-red"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-red"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?(@@ Debug\\(\\d+\\) :)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,} )?(#\\d+: | {4,})?)?(.*\\t([0-9]+)\\s.*)",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-debug"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"},
+        "3": {"name": "vscode-autoit-output-pink"}
       }
     },
     {
-      "match": "^(#[0-9]+: | {4,})?(.*\\(\\d+\\).*)",
+      "match": "^(?:(\\d{2}:\\d{2}:\\d{2}\\.\\d{3,})|(#\\d+: | {4,}))",
       "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-olive"}
+        "1": {"name": "vscode-autoit-output-date"},
+        "2": {"name": "vscode-autoit-output-process-id"}
       }
-    },
-    {
-      "match": "^(#[0-9]+: | {4,})?(In file included from\\s.*)",
-      "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-purple"}
-      }
-    },
-    {
-      "match": "^(#[0-9]+: | {4,})?(line(?:\\s|.)*\\scolumn(?:\\s|.)*)",
-      "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-red"}
-      }
-    },
-    {
-      "match": "^(#[0-9]+: | {4,})?(.*\\t([0-9]+)\\s.*)",
-      "captures":{
-        "1": {"name": "vscode-autoit-output-process-id"},
-        "2": {"name": "vscode-autoit-output-pink"}
-      }
-    },
-    {
-      "match": "^#[0-9]+: | {4,}",
-      "name": "vscode-autoit-output-process-id"
     }
 
   ]


### PR DESCRIPTION
* fixed keybinding error message from AutoIt3Wrapper shown sometimes
* fixed "False" shown on each run script (might be depending on AutoIt3Wrapper version)
* fixed multiouput didn't cleanup if was activated after script was previously run (only reproducible if setting changed without restarting vscode)
* fixed AutoIt3Wrapper.ini fails to restore to its original state when multiple scripts run simultaneously 
* fixed incorrect script run elapsed time
* added proper up-to-date keybinding info in output message when run script
* added toast message if file failed to save prior run/build/compile
* added option to show time in output
* added option to keep _nn_ of lines in output (work around for #118)
* don't allow execute functions if new file hasn't been saved yet
* don't allow tidy/checkscript if file failed to save

P.S.
Probably should create separate PR for each fix/feature...