### PR TITLE
`insertHeader` and `openInclude` commands should only be executed on autoit files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -282,11 +282,13 @@
       },
       {
         "command": "extension.insertHeader",
-        "key": "ctrl+alt+H"
+        "key": "ctrl+alt+H",
+        "when": "editorTextFocus && editorLangId == autoit"
       },
       {
         "command": "extension.openInclude",
-        "key": "alt+i"
+        "key": "alt+i",
+        "when": "editorTextFocus && editorLangId == autoit"
       },
       {
         "command": "extension.restartScript",


### PR DESCRIPTION
Unless there is a reason for this, but `insertHeader` and `openInclude` commands should only be executed on autoit files.