### PR TITLE
Allow enter relative to aiPath paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,27 +307,27 @@
         "autoit.wrapperPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Full or relative path to the AutoIt3Wrapper script, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\AutoIt3Wrapper\\AutoIt3Wrapper.au3`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+          "markdownDescription": "Full or relative path to the AutoIt3Wrapper script, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\AutoIt3Wrapper\\AutoIt3Wrapper.au3`\n\nLeave blank to use default, relative to `#autoit.aiPath#` path."
         },
         "autoit.checkPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Full or relative path to the AutoIt syntax Checker (Au3Check) executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AU3Check.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+          "markdownDescription": "Full or relative path to the AutoIt syntax Checker (Au3Check) executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AU3Check.exe`\n\nLeave blank to use default, relative to `#autoit.aiPath#` path."
         },
         "autoit.helpPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Full or relative path to the AutoIt3Help executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AutoIt3Help.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+          "markdownDescription": "Full or relative path to the AutoIt3Help executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AutoIt3Help.exe`\n\nLeave blank to use default, relative to `#autoit.aiPath#` path."
         },
         "autoit.infoPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Full or relative path to the AutoIt Window Info executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\Au3Info.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+          "markdownDescription": "Full or relative path to the AutoIt Window Info executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\Au3Info.exe`\n\nLeave blank to use default, relative to `#autoit.aiPath#` path."
         },
         "autoit.kodaPath": {
           "type": "string",
           "default": "",
-          "markdownDescription": "Full or relative path to the Koda FormDesigner executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\Koda\\FD.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+          "markdownDescription": "Full or relative path to the Koda FormDesigner executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\Koda\\FD.exe`\n\nLeave blank to use default, relative to `#autoit.aiPath#` path."
         },
         "autoit.smartHelp": {
           "type": "array",

--- a/package.json
+++ b/package.json
@@ -345,6 +345,9 @@
           "default": [
             ""
           ],
+          "description": "File paths for additional include folders",
+          "format": "uri"
+        },
         "autoit.showVariablesInGoToSymbol": {
           "type": "boolean",
           "default": true,
@@ -354,9 +357,6 @@
           "type": "boolean",
           "default": true,
           "description": "Determines whether regions show up when you use Ctrl+Shift+O to find symbols within a script"
-        },
-          "description": "File paths for additional include folders",
-          "format": "uri"
         },
         "autoit.consoleParams": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "id": "autoit",
         "aliases": [
           "AutoIt",
-          "autoit"
+          "Autoit"
         ],
         "extensions": [
           ".au3"

--- a/package.json
+++ b/package.json
@@ -301,49 +301,46 @@
         "autoit.aiPath": {
           "type": "string",
           "default": "C:\\Program Files (x86)\\AutoIt3\\AutoIt3.exe",
-          "markdownDescription": "Path to the AutoIt executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AutoIt3.exe`",
+          "markdownDescription": "Full path to the AutoIt executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\` or `C:\\Program Files (x86)\\AutoIt3\\AutoIt3.exe`",
           "format": "uri"
         },
         "autoit.wrapperPath": {
           "type": "string",
-          "default": "C:\\Program Files (x86)\\AutoIt3\\SciTE\\AutoIt3Wrapper\\AutoIt3Wrapper.au3",
-          "markdownDescription": "Path to the AutoIt3Wrapper script, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\AutoIt3Wrapper\\AutoIt3Wrapper.au3`",
-          "format": "uri"
+          "default": "",
+          "markdownDescription": "Full or relative path to the AutoIt3Wrapper script, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\AutoIt3Wrapper\\AutoIt3Wrapper.au3`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
         },
         "autoit.checkPath": {
           "type": "string",
-          "default": "C:\\Program Files (x86)\\AutoIt3\\AU3Check.exe",
-          "markdownDescription": "Path to the AutoIt syntax Checker (Au3Check) executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AU3Check.exe`",
-          "format": "uri"
+          "default": "",
+          "markdownDescription": "Full or relative path to the AutoIt syntax Checker (Au3Check) executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AU3Check.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
         },
         "autoit.helpPath": {
           "type": "string",
-          "default": "C:\\Program Files (x86)\\AutoIt3\\AutoIt3Help.exe",
-          "description": "Path to the AutoIt3Help executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AutoIt3Help.exe`",
-          "format": "uri"
+          "default": "",
+          "markdownDescription": "Full or relative path to the AutoIt3Help executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\AutoIt3Help.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+        },
+        "autoit.infoPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Full or relative path to the AutoIt Window Info executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\Au3Info.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
+        },
+        "autoit.kodaPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Full or relative path to the Koda FormDesigner executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\Koda\\FD.exe`\n\nLeave blank to use default, relative to `autoit.aiPath` path."
         },
         "autoit.smartHelp": {
           "type": "array",
           "description": "Defines prefixes, paths & sources for additional help files",
           "default": [
-            "",
-            "",
+            ""
+          ]
+        },
+        "autoit.includePaths": {
+          "type": "array",
+          "default": [
             ""
           ],
-          "format": "uri"
-        },
-        "autoit.infoPath": {
-          "type": "string",
-          "default": "C:\\Program Files (x86)\\AutoIt3\\Au3Info.exe",
-          "markdownDescription": "Path to the AutoIt Window Info executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\Au3Info.exe`",
-          "format": "uri"
-        },
-        "autoit.kodaPath": {
-          "type": "string",
-          "default": "C:\\Program Files (x86)\\AutoIt3\\SciTE\\Koda\\FD.exe",
-          "markdownDescription": "Path to the Koda FormDesigner executable, e.g. `C:\\Program Files (x86)\\AutoIt3\\SciTE\\Koda\\FD.exe`",
-          "format": "uri"
-        },
         "autoit.showVariablesInGoToSymbol": {
           "type": "boolean",
           "default": true,
@@ -354,11 +351,6 @@
           "default": true,
           "description": "Determines whether regions show up when you use Ctrl+Shift+O to find symbols within a script"
         },
-        "autoit.includePaths": {
-          "type": "array",
-          "default": [
-            "C:\\Program Files (x86)\\AutoIt3\\Include"
-          ],
           "description": "File paths for additional include folders",
           "format": "uri"
         },

--- a/src/ai_commands.js
+++ b/src/ai_commands.js
@@ -9,6 +9,7 @@ conf.addListener(() => runners.cleanup());
 import { parse } from "jsonc-parser";
 import { commandsList as _commandsList, commandsPrefix} from "./commandsList";
 import { decode, encodingExists } from "iconv-lite";
+import { showInformationMessage, showErrorMessage, messages } from './ai_showMessage';
 
 const runners = {
   list: new Map(), //list of running scripts

--- a/src/ai_commands.js
+++ b/src/ai_commands.js
@@ -3,6 +3,9 @@ import { execFile as launch, spawn } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { findFilepath, getIncludeText } from './util';
+import conf from './ai_config';
+const config = conf.config;
+conf.addListener(() => runners.cleanup());
 
 const runners = {
   list: new Map(), //list of running scripts
@@ -74,22 +77,6 @@ const runners = {
   }
 };
 
-const config = (() => {
-  const conf = {
-    data: workspace.getConfiguration('autoit'),
-  };
-  workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
-    if (!affectsConfiguration('autoit')) return;
-
-    conf.data = workspace.getConfiguration('autoit');
-    runners.cleanup();
-  });
-  return new Proxy(conf,
-    {
-      get(target, prop) { return target.data[prop]; },
-      set(target, prop, val) { return target.data.update(prop, val); }
-    });
-})();
 
 //AutoIt3Wrapper.au3 sets CTRL+Break and CTRL+ALT+Break hotkeys
 //they interfere with this extension (unless user changed hotkeys)

--- a/src/ai_config.js
+++ b/src/ai_config.js
@@ -1,0 +1,158 @@
+
+import { workspace, Uri, FileType} from 'vscode';
+import { showInformationMessage, showErrorMessage } from './ai_showMessage';
+const conf = {
+  data: workspace.getConfiguration('autoit'),
+  paths:{
+    aiPath: {file: "AutoIt3.exe"},
+    wrapperPath: {dir: "SciTE\\AutoIt3Wrapper\\", file: "AutoIt3Wrapper.au3"},
+    checkPath: {file: "AU3Check.exe"},
+    helpPath: {file: "AutoIt3Help.exe"},
+    infoPath: {file: "Au3Info.exe"},
+    kodaPath: {dir: "SciTE\\Koda\\", file: "FD.exe"},
+    includePaths: [{dir: ""}],
+    smartHelp: [{dir: "", file: ""}]
+  }
+};
+
+const listeners = new Map();
+let listenerId = 0, aiPath = "";
+workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
+  if (!affectsConfiguration('autoit')) return;
+
+  conf.data = workspace.getConfiguration('autoit');
+  listeners.forEach(listener => {
+    try{listener();}catch(er){console.error(er);}
+  });
+  getPaths();
+});
+
+getPaths();
+
+function addListener(listener) {
+  listeners.set(++listenerId, listener);
+  return listenerId;
+}
+
+function removeListener(id) {
+  listeners.remove(id);
+}
+
+function splitPath(path)
+{
+  path = path.trim().match(/^(.*[\\/])?([^\\/]+)?$/).map(a => a || "");
+
+  return {
+    path: path[0],
+    dir: path[1] + (path[1] === "" ? "" : "\\"),
+    file: path[2],
+    isRelative: !!(path[1] && !path[1].match(/^[a-zA-Z]:[\\/]/))
+  };
+}
+
+function fixPath (key, value, index)
+{
+  const path = splitPath(value || "");
+  const file = (conf.paths[key][index] || conf.paths[key]).file;
+  const dir = (conf.paths[key][index] || conf.paths[key]).dir;
+  if (path.file === "")
+    path.file = file || "";
+
+  if (path.dir === "" || path.isRelative)
+    path.dir = aiPath.dir + path.dir + (!path.isRelative ? (dir || "") : "");
+  
+  if (file === undefined)
+    path.file += "/";
+
+  return (path.dir + "/" + path.file).replace(/[\\/]+/g, "\\");
+}
+
+function verifyPath (val, obj, key, index)
+{
+  const showError = () =>
+  {
+    const timeout = obj.message && !obj.message.isHidden ? 1000 : 0;
+    if (timeout) {
+      obj.message.hide();
+      delete obj.message;
+    }
+
+    if (obj.prevCheck !== val)
+    {
+      const type = (conf.paths[key][index] || conf.paths[key]).file !== undefined ? "File" : "Directory";
+      setTimeout(() => obj.message = showErrorMessage(`${type} "${obj.fullPath}" not found (autoit.${key}${index === undefined ? '' : ` [${index}]`})`), timeout);
+    }
+
+    obj.prevCheck = val;
+  };
+
+  workspace.fs.stat(Uri.parse(`file:///${obj.fullPath}`)).then(data => {
+    const type = ((conf.paths[key][index] || conf.paths[key]).file !== undefined ? FileType.File : FileType.Directory) | FileType.SymbolicLink;
+    if (!(data.type & type))
+      return showError();
+
+    if (obj.message)
+    {
+      obj.message.hide();
+      delete obj.message;
+    }
+    obj.prevCheck = val;
+
+  }).catch(() =>
+  {
+    showError();
+  });
+}
+
+function getPaths()
+{
+  aiPath = splitPath(conf.data.aiPath||"");
+
+  for(let i in conf.paths)
+  {
+    const value = conf.data[i];
+    if (Array.isArray(value)) {
+      for(let j = 0; j < value.length; j++ )
+      {
+        const val = value[j].trim();
+        if (conf.paths[i][j] === undefined)
+          conf.paths[i][j] = Object.assign({fullPath: ""}, conf.paths[i][0]);
+
+          const obj = conf.paths[i][j];
+
+        if (val !== "")
+          obj.fullPath = fixPath(i, val, j);
+
+        if (obj.fullPath === undefined)
+          obj.fullPath = "";
+
+        verifyPath(val, obj, i, j);
+      }
+    }
+    else {
+      const obj = conf.paths[i];
+      obj.fullPath = fixPath(i, value);
+      verifyPath(value, obj, i);
+    }
+
+  }
+}
+const config = new Proxy(conf,
+{
+  get(target, prop) {
+    if (target.paths[prop]) {
+      if (Array.isArray(target.paths[prop]))
+        return target.paths[prop].map(a => a.fullPath);
+
+      return target.paths[prop].fullPath;
+    }
+    return target.data[prop];
+  },
+  set(target, prop, val) { return target.data.update(prop, val); }
+});
+
+export default {
+  config,
+  addListener,
+  removeListener
+};

--- a/src/ai_showMessage.js
+++ b/src/ai_showMessage.js
@@ -43,3 +43,4 @@ const initMessage = (type) => {
 };
 export const showInformationMessage = initMessage("showInformationMessage");
 export const showErrorMessage = initMessage("showErrorMessage");
+export const messages = {error:{},info:{}};

--- a/src/ai_showMessage.js
+++ b/src/ai_showMessage.js
@@ -1,0 +1,45 @@
+import { window } from "vscode";
+let lastHide = 0;
+//accepts new option parameter in second argument: timeout
+const initMessage = (type) => {
+  const timers = {};
+  const func = (...args) => {
+    let timeout;
+    const [message, options] = args;
+    if (options && options instanceof Object && !(options instanceof Array)) {
+      timeout = options.timeout;
+      //not sure if we need to bother sanitize options object or not, seems to work as is
+      // delete options.timeout;
+      // if (!options.keys().length)
+      //   args.splice(1,1);
+    }
+    const _clearTimeout = () =>{
+      clearTimeout(timers[message]);
+      delete(timers[message]);
+    };
+    _clearTimeout();
+    let isHidden = false;
+    const callback = () => {
+      _clearTimeout();
+      // https://github.com/microsoft/vscode/issues/153693
+      for (let i = 0; i < 4; i++) // showing rapidly 4 messages hides the message...an exploit?
+        window[type].apply(window[type], args);
+
+      isHidden = true;
+      lastHide = performance.now();
+    };
+    timers[message] = timeout !== undefined && setTimeout(callback, timeout);
+    //vscode doesn't display new message if previous message was forcibly hidden less then 1 sec ago
+    const messageTimeout = 900 - (performance.now() - lastHide);
+    return {
+      get isHidden() {
+        return isHidden;
+      },
+      hide: callback,
+      message: new Promise(resolve => setTimeout(() => resolve(window[type].apply(window[type], args).finally(_clearTimeout)), messageTimeout))
+    };
+  };
+  return func;
+};
+export const showInformationMessage = initMessage("showInformationMessage");
+export const showErrorMessage = initMessage("showErrorMessage");

--- a/src/extension.js
+++ b/src/extension.js
@@ -12,15 +12,14 @@ const goToDefinitionFeature = require('./ai_definition');
 
 const { registerCommands } = require('./registerCommands');
 const { parseAu3CheckOutput } = require('./diagnosticUtils');
-
+const config = require("./ai_config").default.config;
 let diagnosticCollection;
 
 const checkAutoItCode = document => {
-  const { checkPath, enableDiagnostics } = vscode.workspace.getConfiguration('autoit');
 
   diagnosticCollection.clear();
 
-  if (!enableDiagnostics) {
+  if (!config.enableDiagnostics) {
     return;
   }
 
@@ -28,14 +27,13 @@ const checkAutoItCode = document => {
     return;
   }
 
-  if (!fs.existsSync(checkPath)) {
+  if (!fs.existsSync(config.checkPath)) {
     vscode.window.showErrorMessage(
       'Invalid Check Path! Please review AutoIt settings (Check Path in UI, autoit.checkPath in JSON)',
     );
     return;
   }
-
-  const checkProcess = spawn(checkPath, [document.fileName], {
+  const checkProcess = spawn(config.checkPath, [document.fileName], {
     cwd: path.dirname(document.fileName),
   });
 
@@ -47,7 +45,7 @@ const checkAutoItCode = document => {
   });
 
   checkProcess.stderr.on('error', error => {
-    vscode.window.showErrorMessage(`${checkPath} error: ${error}`);
+    vscode.window.showErrorMessage(`${config.checkPath} error: ${error}`);
   });
 };
 


### PR DESCRIPTION
With this change only `autoit.aiPath` is required, all other paths can be left blank, in which case will use default, relative to `autoit.aiPath` path. It also allows specify relative paths (`x:\` considered as full path). If entered path ends without `\` it considered path of executable (for the exeption of `autoit.includePaths`), otherwise default executable name will be appended.