### PR TITLE
Improve syntax highlighting of comment blocks

### DIFF
--- a/syntaxes/autoit.tmLanguage
+++ b/syntaxes/autoit.tmLanguage
@@ -113,9 +113,9 @@
       </dict>
       <dict>
         <key>begin</key>
-        <string>(?i:#c(?:omments\-start|s))</string>
+        <string>(?i:^\s*#c(?:omments\-start|s))</string>
         <key>end</key>
-        <string>(?i:#c(?:omments\-end|e))\b.*$</string>
+        <string>(?i:^\s*#c(?:omments\-end|e))\b.*$</string>
         <key>name</key>
         <string>comment.block.autoit</string>
       </dict>


### PR DESCRIPTION
Originally reported [here](https://github.com/damien122/Autoit-Visual-Studio-Extension/pull/5) by @Murenysh with this code for testing --

```autoit
#comments-start
For $i = 0 To UBound($BaseList) - 1
If $BaseList[$i][1] = "Connect=" & $ConnectionString Then
$IBName = $BaseList[$i][0]

    ;#comments-start
    If StringLeft($IBName, 1) = "[" And StringRight($IBName, 1) = "]" Then
        $IBName = StringMid($IBName, 2, StringLen($IBName) - 2)
    EndIf

    Return $IBName
    ;#comments-end

EndIf

Next
#comments-end
```