### PR TITLE
Fix diagnostics

### DIFF
--- a/src/diagnosticUtils.js
+++ b/src/diagnosticUtils.js
@@ -31,13 +31,19 @@ export const updateDiagnostics = (currentDiagnostics, scriptPath, range, descrip
  * Processes the results of AU3Check, identifies warnings and errors.
  * @param {string} output Text returned from AU3Check.
  * @param {vscode.DiagnosticCollection} collection - The diagnostic collection to update.
+ * @param {vscode.Uri} docURI - The URI of the document that was checked
  */
-export const parseAu3CheckOutput = (output, collection) => {
+export const parseAu3CheckOutput = (output, collection, docURI) => {
   const OUTPUT_REGEXP = /"(?<scriptPath>.+)"\((?<line>\d{1,4}),(?<position>\d{1,4})\)\s:\s(?<severity>warning|error):\s(?<description>.+)\./gm;
   let matches = null;
   let diagnosticRange;
   let diagnosticSeverity;
   let diagnostics = {};
+
+  if (output.includes('- 0 error(s), 0 warning(s)')) {
+    collection.delete(docURI);
+    return;
+  }
 
   matches = OUTPUT_REGEXP.exec(output);
   while (matches !== null) {

--- a/src/diagnosticUtils.js
+++ b/src/diagnosticUtils.js
@@ -34,7 +34,7 @@ export const updateDiagnostics = (currentDiagnostics, scriptPath, range, descrip
  * @param {vscode.Uri} docURI - The URI of the document that was checked
  */
 export const parseAu3CheckOutput = (output, collection, docURI) => {
-  const OUTPUT_REGEXP = /"(?<scriptPath>.+)"\((?<line>\d{1,4}),(?<position>\d{1,4})\)\s:\s(?<severity>warning|error):\s(?<description>.+)\./gm;
+  const OUTPUT_REGEXP = /"(?<scriptPath>.+)"\((?<line>\d{1,4}),(?<position>\d{1,4})\)\s:\s(?<severity>warning|error):\s(?<description>.+)\r/gm;
   let matches = null;
   let diagnosticRange;
   let diagnosticSeverity;

--- a/src/extension.js
+++ b/src/extension.js
@@ -86,11 +86,11 @@ const activate = ctx => {
       checkAutoItCode(editor.document, diagnosticCollection);
     }
   });
-  vscode.workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
-    if (affectsConfiguration('autoit') && vscode.window.activeTextEditor) {
-      checkAutoItCode(vscode.window.activeTextEditor.document, diagnosticCollection);
-    }
-  });
+
+  // Run diagnostic on document that's open when the extension loads
+  if (config.enableDiagnostics && vscode.window.activeTextEditor) {
+    checkAutoItCode(vscode.window.activeTextEditor.document, diagnosticCollection);
+  }
 
   // eslint-disable-next-line no-console
   console.log('AutoIt is now active!');

--- a/src/extension.js
+++ b/src/extension.js
@@ -15,9 +15,11 @@ const { parseAu3CheckOutput } = require('./diagnosticUtils');
 const { config } = require('./ai_config').default;
 
 let diagnosticCollection;
+let consoleOutput;
 
 const checkAutoItCode = document => {
   diagnosticCollection.clear();
+  consoleOutput = '';
 
   if (!config.enableDiagnostics) {
     return;
@@ -41,11 +43,15 @@ const checkAutoItCode = document => {
     if (data.length === 0) {
       return;
     }
-    parseAu3CheckOutput(data.toString(), diagnosticCollection);
+    consoleOutput += data.toString();
   });
 
   checkProcess.stderr.on('error', error => {
     vscode.window.showErrorMessage(`${config.checkPath} error: ${error}`);
+  });
+
+  checkProcess.on('close', () => {
+    parseAu3CheckOutput(consoleOutput, diagnosticCollection);
   });
 };
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -78,6 +78,9 @@ const activate = ctx => {
   vscode.workspace.onDidOpenTextDocument(document =>
     checkAutoItCode(document, diagnosticCollection),
   );
+  vscode.workspace.onDidCloseTextDocument(document => {
+    diagnosticCollection.delete(document.uri);
+  });
   vscode.window.onDidChangeActiveTextEditor(editor => {
     if (editor) {
       checkAutoItCode(editor.document, diagnosticCollection);

--- a/src/extension.js
+++ b/src/extension.js
@@ -14,14 +14,11 @@ const { registerCommands } = require('./registerCommands');
 const { parseAu3CheckOutput } = require('./diagnosticUtils');
 const { config } = require('./ai_config').default;
 
-let diagnosticCollection;
-let consoleOutput;
-
-const checkAutoItCode = document => {
-  diagnosticCollection.clear();
-  consoleOutput = '';
+const checkAutoItCode = (document, diagnosticCollection) => {
+  let consoleOutput = '';
 
   if (!config.enableDiagnostics) {
+    diagnosticCollection.clear();
     return;
   }
 
@@ -51,7 +48,7 @@ const checkAutoItCode = document => {
   });
 
   checkProcess.on('close', () => {
-    parseAu3CheckOutput(consoleOutput, diagnosticCollection);
+    parseAu3CheckOutput(consoleOutput, diagnosticCollection, document.uri);
   });
 };
 
@@ -72,14 +69,18 @@ const activate = ctx => {
 
   registerCommands();
 
-  diagnosticCollection = vscode.languages.createDiagnosticCollection('autoit');
+  const diagnosticCollection = vscode.languages.createDiagnosticCollection('autoit');
   ctx.subscriptions.push(diagnosticCollection);
 
-  vscode.workspace.onDidSaveTextDocument(document => checkAutoItCode(document));
-  vscode.workspace.onDidOpenTextDocument(document => checkAutoItCode(document));
+  vscode.workspace.onDidSaveTextDocument(document =>
+    checkAutoItCode(document, diagnosticCollection),
+  );
+  vscode.workspace.onDidOpenTextDocument(document =>
+    checkAutoItCode(document, diagnosticCollection),
+  );
   vscode.window.onDidChangeActiveTextEditor(editor => {
     if (editor) {
-      checkAutoItCode(editor.document);
+      checkAutoItCode(editor.document, diagnosticCollection);
     }
   });
 

--- a/src/extension.js
+++ b/src/extension.js
@@ -86,6 +86,11 @@ const activate = ctx => {
       checkAutoItCode(editor.document, diagnosticCollection);
     }
   });
+  vscode.workspace.onDidChangeConfiguration(({ affectsConfiguration }) => {
+    if (affectsConfiguration('autoit') && vscode.window.activeTextEditor) {
+      checkAutoItCode(vscode.window.activeTextEditor.document, diagnosticCollection);
+    }
+  });
 
   // eslint-disable-next-line no-console
   console.log('AutoIt is now active!');


### PR DESCRIPTION
Resolves issues where items were missing from the Problems tab, which occurred when `parseAu3CheckOutput` was called multiple times when processing the output from Au3Check