### PR TITLE
provideDefinition: Additional null testing

### DIFF
--- a/src/ai_definition.js
+++ b/src/ai_definition.js
@@ -23,7 +23,7 @@ const AutoItDefinitionProvider = {
     // If nothing was found, search include files
     match = this.findDefinitionInIncludeFiles(documentText, definitionRegex, document);
 
-    if (match.found) {
+    if (match && match.found) {
       const { scriptPath } = match;
       const scriptContentBeforeMatch = match.scriptContent
         .slice(0, match.found.index + (match[1] || '').length)


### PR DESCRIPTION
Restores check for `match` being null to eliminate runtime error.