### PR TITLE
Remove unsupported binary syntax from tmLanguage

### DIFF
--- a/syntaxes/autoit.tmLanguage
+++ b/syntaxes/autoit.tmLanguage
@@ -235,7 +235,6 @@
         <key>match</key>
         <string>(?x)
           (?:0x\h+) |                  # Hex
-          (?:0b[01]+) |                # Binary
           (?:-?(?:\d+\.?\d*|\.\d+))    # Decimal
           (?:[eE][-+]?\d+)?            # Optional exponent
         </string>


### PR DESCRIPTION
The change is based on the issue #225 