### PR TITLE
Scite-like coloring misc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Includes without trailing space now colorize correctly.
 
+### Changed
+
+- Separated some preprocesors to be colored closer to Scite.
+  - Token scope (`keyword.control.directives.autoit`) now is used for `Include-Once`, `NoTrayIcon`, `RequireAdmin` and `OnAutoItStartRegister`
+  - Token scope (`meta.preprocessor.autoit`) is used for all others.
+
 ## [1.4.0] - 2026-02-13
 
 ### Added

--- a/syntaxes/autoit.tmLanguage.json
+++ b/syntaxes/autoit.tmLanguage.json
@@ -73,22 +73,22 @@
       "name": "keyword.control.import.autoit"
     },
     {
-      "captures": {
-        "1": {
-          "name": "string.parameter.directives.autoit"
-        }
-      },
-      "match": "^\\s*#\\b(?i:include-once|notrayicon|onautoitstartregister|requireadmin|endregion|forcedef|forceref|ignorefunc|pragma|region)\\b([^;\\r\\n]*)",
-      "name": "keyword.control.directives.autoit"
-    },
-    {
-      "name": "keyword.control.directives.autoit",
-      "match": "^\\s*(#)(AutoIt3Wrapper_\\w+|Au3Stripper_\\w+|Tidy_(Parameters|On|Off|ILC_Pos))\\b",
-      "captures": {
-        "1": {
-          "name": "meta.preprocessor.autoit"
-        }
-      }
+      "name": "string.parameter.directives.autoit",
+      "match": "^\\s*(#\\b(?i:include-once|notrayicon|onautoitstartregister|requireadmin|endregion|forcedef|forceref|ignorefunc|pragma|region|AutoIt3Wrapper_\\w+|Au3Stripper_\\w+|Tidy_(?:Parameters|On|Off|ILC_Pos)))\\b([^;\\r\\n]*)",
+         "captures": {
+          "1": {
+            "patterns": [
+              {
+                "name": "meta.preprocessor.autoit",
+                "match": "(#(?i:forcedef|forceref|ignorefunc|pragma|AutoIt3Wrapper_\\w+|Au3Stripper_\\w+|Tidy_(?:Parameters|On|Off|ILC_Pos)|endregion|region))"
+              },
+              {
+                "name": "keyword.control.directives.autoit",
+                "match": "(#(?i:include-once|notrayicon|requireadmin|onautoitstartregister))"
+              }
+            ]
+          }
+         }
     },
     {
       "begin": "(?i:^\\s*#c(?:omments\\-start|s))\\b.*$",


### PR DESCRIPTION
- Apply  **meta.preprocessor.autoit** token name to **ForceDef**, **ForceRef**, **AU3Wrapper**, etc.
- Apply **keyword.control.directives.autoit** to **Include-Once**, **NoTrayIcon,** **OnAutoItStartRegister**, and **RequireAdmin**, thus they would be colored the same as #Include 
- Apply **string.parameter.directives.autoit** to parameters after Tidy_, AU3Wrapper_, AU3Stripper_
- Make the space in the RegExp pattern after #Include optional.

I also noticed that **meta.function.autoit** now is applied to all parameters of a function declaration, preventing their being colorized as variables, but not if the function declaration is continued on the next line. I'm not sure if you want it this way? Or not? 

Please see Feature request #237
Thank you!