### PR TITLE
Add community standard files

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.yml
@@ -1,0 +1,73 @@
+name: ⭐ Feature Request
+description: Suggest a new feature or improvement to the project.
+title: "[FEATURE]: "
+labels:
+  - "enhancement"
+  - "documentation"
+  - "help wanted"
+  - "good first issue"
+
+body:
+  - type: markdown
+    id: introduction
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request 💛 it's very appreciated!
+        Please provide as much detail as possible to help us understand and potentially implement the feature.
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: What feature would you like, or what problem are you facing?
+      description: Describe the feature you would like to see implemented or the problem you are experiencing.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: What's your proposed solution?
+      description: A clear description of the enhancement you propose. Please include relevant information and resources if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, please add screenshots to help explain your request.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: assignee
+    attributes:
+      label: Do you want to work on this issue/improvement?
+      options:
+        - "Maybe"
+        - "Yes"
+        - "No"
+      default: 0
+      multiple: false
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Any additional context?
+      description: Add any other relevant context about your proposed solution.
+      placeholder: |
+        Examples:
+
+        - The solution will affect other functions (potential script breaking changes) ...
+        - Influences and relationship to other functionality ...
+        - My considered alternatives are ...
+    validations:
+      required: false
+
+  - type: markdown
+    id: thanks
+    attributes:
+      value: |
+        Thanks for your effort and interest ✌️ in improving the project.

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -1,0 +1,132 @@
+name: 🪲 Bug Report
+description: Report a bug or unexpected behavior to help improve the project.
+title: "[BUG]: "
+labels:
+  - "bug"
+  - "invalid"
+
+body:
+  - type: markdown
+    id: introduction
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report 💛 it's very appreciated!
+        Please provide as much detail as possible to help us identify and fix the issue.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug you have found. Please include relevant information and resources if applicable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What did you expect to happen?
+      description: A clear description of what you think the expected behavior should be.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Which steps did you take to reproduce the bug?
+      description: A clear description of the steps taken to reproduce the buggy behavior.
+      placeholder: |
+        You know the steps? Please try to follow the format below to provide steps to reproduce.
+
+        1. Go to ...
+        2. Click on ...
+        3. Scroll down to ...
+        4. Do this and that ...
+        5. See error
+
+        You don't know the exact steps? Just include any relevant details like:
+
+        - What you were trying to do ...
+        - What went wrong ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, please add screenshots to help explain your problem.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of the project are you running? See Releases (or TAGs) of the repository.
+      options:
+        - latest version
+        - older version
+        - unknown
+      default: 0
+      multiple: false
+    validations:
+      required: true
+
+  - type: input
+    id: specific-version
+    attributes:
+      label: Older or unknown version?
+      description: In case there are no Releases (or TAGs) in the repository yet, please see possible version information within the code base.
+      placeholder: |
+        Example: "0.17.1" or "0.5.0 - 2026-01-22"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: assignee
+    attributes:
+      label: Do you want to work on this issue/fix?
+      options:
+        - "Maybe"
+        - "Yes"
+        - "No"
+      default: 0
+      multiple: false
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: system-under-test
+    attributes:
+      label: What system are you running?
+      description: Please select all applicable options where the bug occurred for you.
+      options:
+        - label: Windows 11 (x64)
+        - label: Windows 10 (x64)
+        - label: Windows 10 (x86)
+        - label: other Windows version
+        - label: other operating system
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Any additional context?
+      description: Add any other context about the problem or your specific environment here if relevant.
+      placeholder: |
+        Examples:
+
+        - I am using Browser version ...
+        - I am using Go version ...
+        - I am using Node.js version ...
+        - I am using AutoIt version ...
+        - I am using .NET (C#) version ...
+    validations:
+      required: false
+
+  - type: markdown
+    id: thanks
+    attributes:
+      value: |
+        Thanks for your effort and interest ✌️ in improving the project.

--- a/.github/ISSUE_TEMPLATE/3-general-question.yml
+++ b/.github/ISSUE_TEMPLATE/3-general-question.yml
@@ -1,0 +1,51 @@
+name: 💬 General Question
+description: Ask a general question or start a discussion about the project.
+title: "[QUESTION]: "
+labels:
+  - "question"
+
+body:
+  - type: markdown
+    id: introduction
+    attributes:
+      value: |
+        Thanks for your interest in the project 💛 feel free to ask any general questions or start a discussion here.
+        Please provide as much detail as possible to help others understand your question or topic.
+
+  - type: textarea
+    id: question-topic
+    attributes:
+      label: What is your question or topic?
+      description: Clearly state your question or the topic you want to discuss.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: What context or background information can you provide?
+      description: Add any relevant details, background, or examples to help others understand your question.
+    validations:
+      required: false
+
+  - type: textarea
+    id: prior-attempts
+    attributes:
+      label: What have you tried or researched already?
+      description: Briefly describe any steps you've taken or resources you've checked before posting your question.
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra-info
+    attributes:
+      label: Any additional comments?
+      description: Add any other comments, links, or related discussions here.
+    validations:
+      required: false
+
+  - type: markdown
+    id: thanks
+    attributes:
+      value: |
+        Thanks for your effort and interest ✌️ in improving the project.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Generally curious?
+    url: https://github.com/loganch
+    about: Feel free to explore my profile and repositories on GitHub.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,98 @@
+<!--
+> [!IMPORTANT]
+> Thanks for your effort and interest 💛 in improving the project. It's very appreciated.
+-->
+
+## Description
+
+<!-- Describe the purpose and main changes of this Pull Request (PR), including the problem it solves or the improvement it brings. -->
+
+#### 🔗 Linked GitHub Issues
+
+<!-- In case this addresses a GitHub issue, please link it here. -->
+
+Closes #\<number>
+
+#### 📋 What is the current behavior?
+
+<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
+
+#### 🚀 What is the new behavior?
+
+<!-- Please describe the behavior or changes that are being added by this PR. -->
+
+<br>
+
+## Type of changes
+
+- [ ] 🪲 Bugfix (change which fixes an issue)
+- [ ] ⭐ New Feature (change which adds functionality)
+- [ ] 🔒 Security fix (change which improves security)
+- [ ] 🔮 Code style update (formatting, renaming)
+- [ ] 🔨 Refactoring (code optimization without functional change)
+- [ ] 📚 Documentation (updates to README or docs)
+- [ ] ⚙️ Build or CI related changes
+- [ ] 🧿 Other type <!-- please describe -->
+
+<br>
+
+## Breaking changes 🔥
+
+<!-- Does this PR introduce breaking changes to existing functionality? If yes, please describe what will break and what users need to do to adapt. -->
+
+- [ ] Yes <!-- please describe -->
+- [ ] No
+
+<br>
+
+## How and where was this tested?
+
+#### 🖥️ Describe where you tested your changes
+
+*System:*
+
+- [ ] Windows 11 (x64)
+- [ ] Windows 10 (x64)
+- [ ] Windows 10 (x86)
+- [ ] other Windows version
+- [ ] other operating system
+
+*Context:*
+
+- [ ] in Browser \<name and version>
+- [ ] with Go \<version>
+- [ ] with Node.js \<version>
+- [ ] with AutoIt \<version>
+- [ ] with .NET (C#) \<version>
+- [ ] with ...
+
+#### 🔬 Describe how you tested your changes
+
+- [ ] Manually tested in system and context shown above
+- [ ] Ran automatic tests (unit tests, integration tests, etc.)
+- [ ] Other ways <!-- please describe -->
+
+<br>
+
+## Checklist
+
+- [ ] I have read and understood the available contributing guidelines.
+- [ ] I have ensured my code follows the available code conventions.
+- [ ] I have reviewed my changes.
+- [ ] I have made corresponding changes to the documentation (if applicable).
+- [ ] I have added/updated necessary tests to cover the changes (if applicable).
+- [ ] I have checked for potential security implications.
+
+<br>
+
+## Additional context
+
+<!-- Add any other context about the problem or improvement here, if relevant. -->
+
+#### Screenshots
+
+<!-- If relevant, provide before/after comparisons or GIFs of UI changes. -->
+
+#### Note to reviewers
+
+<!-- Add any notes for reviewers here. -->


### PR DESCRIPTION
Hi @loganch , this PR closes #239 .

These GitHub community standard files enrich the user experience in terms of using "Issues" and "Pull requests". Furthermore, the files should lead to more uniform and complete information being provided in the forms (templates).

Best regards
Sven

FYI: @mlipok, @donnyh13